### PR TITLE
Removed early install of pipes-attoparsec in lieu of changes in marquise...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ install:
   - 'git clone https://github.com/anchor/nagios-perfdata'
   - 'git clone https://github.com/anchor/gearman-haskell'
   - 'cd ..'
-  - 'cabal-$CABALVER install pipes-attoparsec'
   - 'cabal-$CABALVER sandbox add-source ./deps/vaultaire-common'
   - 'cabal-$CABALVER sandbox add-source ./deps/marquise'
   - 'cabal-$CABALVER sandbox add-source ./deps/nagios-perfdata'

--- a/vaultaire-collector-nagios.cabal
+++ b/vaultaire-collector-nagios.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-nagios
-version:             3.3.1
+version:             3.3.2
 synopsis:            Vaultaire collector for Nagios perfdata
 homepage:            https://github.com/anchor/vaultaire-collector-nagios
 license:             BSD3
@@ -23,7 +23,7 @@ library
 
   build-depends:       base >= 4.7,
                        nagios-perfdata >= 0.2.0,
-                       marquise,
+                       marquise >= 2.8.2,
                        vaultaire-common,
                        gearman-haskell >= 0.2.0,
                        optparse-applicative,


### PR DESCRIPTION
...-2.8.2

Marquise 2.8.2 has a minimum version requirement for pipes-attoparsec which
should force cabal to not install a lower version of pipes-attoparsec and
cause travis builds to fail
